### PR TITLE
provide a SDK client for workload

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,137 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	naglfarv1 "github.com/PingCAP-QE/Naglfar/api/v1"
+	"github.com/PingCAP-QE/Naglfar/controllers"
+	"github.com/PingCAP-QE/Naglfar/pkg/tiup"
+	tiupSpec "github.com/pingcap/tiup/pkg/cluster/spec"
+)
+
+type Client struct {
+	client.Client
+}
+
+var (
+	namespace        string
+	testWorkloadName string
+	workloadItemName string
+
+	// k8s
+	scheme *runtime.Scheme
+)
+
+func (c *Client) GetTiDBClusterTopology(ctx context.Context, clusterName string) (*tiupSpec.Specification, error) {
+	originCluster := os.Getenv(clusterName)
+	if len(originCluster) == 0 {
+		originCluster = clusterName
+	}
+	topology, err := c.getClusterTopology(ctx, originCluster)
+	if err != nil {
+		return nil, err
+	}
+	if topology.Spec.TiDBCluster == nil {
+		panic(fmt.Sprintf("incorrect cluster topology used, please check the cluster: %s, %s", clusterName, originCluster))
+	}
+	resources, err := c.getTestResources(ctx)
+	if err != nil {
+		return nil, err
+	}
+	spec, _, err := tiup.BuildSpecification(&topology.Spec, resources)
+	return &spec, err
+}
+
+func (c *Client) getTestResources(ctx context.Context) ([]*naglfarv1.TestResource, error) {
+	var resourceList naglfarv1.TestResourceList
+	var resources []*naglfarv1.TestResource
+	if err := c.List(ctx, &resourceList, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+	for _, item := range resourceList.Items {
+		resources = append(resources, &item)
+	}
+	return resources, nil
+}
+
+func (c *Client) getClusterTopology(ctx context.Context, clusterName string) (*naglfarv1.TestClusterTopology, error) {
+	var ct naglfarv1.TestClusterTopology
+	ct.Namespace = namespace
+	ct.Name = clusterName
+	key, err := client.ObjectKeyFromObject(&ct)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Get(ctx, key, &ct); err != nil {
+		return nil, err
+	}
+	return &ct, nil
+}
+
+func (c *Client) getTestWorkload(ctx context.Context) (*naglfarv1.TestWorkload, error) {
+	var workload naglfarv1.TestWorkload
+	workload.Namespace = namespace
+	workload.Name = testWorkloadName
+	key, err := client.ObjectKeyFromObject(&workload)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Get(ctx, key, &workload); err != nil {
+		return nil, err
+	}
+	return &workload, nil
+}
+
+// NewClient creates the Naglfar client
+func NewClient(kubeconfig string) (*Client, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	cli, err := client.New(config, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return nil, nil
+	}
+	return &Client{
+		cli,
+	}, nil
+}
+
+func init() {
+	namespace = os.Getenv(controllers.NaglfarClusterNs)
+	testWorkloadName = os.Getenv(controllers.NaglfarTestWorkloadName)
+	workloadItemName = os.Getenv(controllers.NaglfarTestWorkloadItem)
+
+	scheme = runtime.NewScheme()
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(kubescheme.AddToScheme(scheme))
+	utilruntime.Must(naglfarv1.AddToScheme(scheme))
+}

--- a/client/report.go
+++ b/client/report.go
@@ -1,0 +1,47 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	naglfarv1 "github.com/PingCAP-QE/Naglfar/api/v1"
+)
+
+func (c *Client) SetTestWorkloadResult(ctx context.Context, text string) error {
+	var testWorkload naglfarv1.TestWorkload
+	testWorkload.Namespace, testWorkload.Name = namespace, testWorkloadName
+	key, err := client.ObjectKeyFromObject(&testWorkload)
+	if err != nil {
+		return err
+	}
+	if err := c.Get(ctx, key, &testWorkload); err != nil {
+		return err
+	}
+	return retry(3, 1*time.Second, func() error {
+		testWorkload.Status.Results[workloadItemName] = naglfarv1.TestWorkloadResult{
+			PlainText: text,
+		}
+		if err := c.Update(ctx, &testWorkload); err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/client/util.go
+++ b/client/util.go
@@ -1,0 +1,38 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"time"
+)
+
+func retry(attempts int, sleep time.Duration, f func() error) (err error) {
+	for i := 0; ; i++ {
+		err = f()
+		if err == nil {
+			return
+		}
+
+		if i >= (attempts - 1) {
+			break
+		}
+
+		time.Sleep(sleep)
+	}
+	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
+}

--- a/config/crd/bases/naglfar.pingcap.com_testresources.yaml
+++ b/config/crd/bases/naglfar.pingcap.com_testresources.yaml
@@ -76,77 +76,13 @@ spec:
               items:
                 type: string
               type: array
-<<<<<<< HEAD
-            hostIP:
-              description: HostIP is the ip address of the host machine
-              type: string
-=======
-            diskStat:
-              additionalProperties:
-                properties:
-                  device:
-                    type: string
-                  kind:
-                    enum:
-                    - nvme
-                    - other
-                    type: string
-                  mountPath:
-                    type: string
-                  originPath:
-                    type: string
-                  size:
-                    type: string
-                required:
-                - device
-                - kind
-                - mountPath
-                - originPath
-                - size
-                type: object
-              type: object
             envs:
               items:
                 type: string
               type: array
-            hostMachine:
-              description: ObjectReference contains enough information to let you
-                inspect or modify the referred object.
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
->>>>>>> master
+            hostIP:
+              description: HostIP is the ip address of the host machine
+              type: string
             image:
               type: string
             mount:

--- a/controllers/testclustertopology_controller.go
+++ b/controllers/testclustertopology_controller.go
@@ -178,7 +178,7 @@ func (r *TestClusterTopologyReconciler) installTiDBCluster(ctx context.Context, 
 	if requeue {
 		return true, nil
 	}
-	tiupCtl, err := tiup.MakeClusterManager(log, ct.Spec.DeepCopy(), rr, resources)
+	tiupCtl, err := tiup.MakeClusterManager(log, ct.Spec.DeepCopy(), resources)
 	if err != nil {
 		return false, err
 	}
@@ -212,7 +212,7 @@ func (r *TestClusterTopologyReconciler) deleteTopology(ctx context.Context, ct *
 			for idx := range resourceList.Items {
 				resources = append(resources, &resourceList.Items[idx])
 			}
-			tiupCtl, err := tiup.MakeClusterManager(r.Log, ct.Spec.DeepCopy(), &rr, resources)
+			tiupCtl, err := tiup.MakeClusterManager(r.Log, ct.Spec.DeepCopy(), resources)
 			if err != nil {
 				return err
 			}

--- a/controllers/testclustertopology_controller.go
+++ b/controllers/testclustertopology_controller.go
@@ -140,9 +140,9 @@ func (r *TestClusterTopologyReconciler) installTiDBCluster(ctx context.Context, 
 	filterClusterResources := func() []*naglfarv1.TestResource {
 		allHosts := ct.Spec.TiDBCluster.AllHosts()
 		result := make([]*naglfarv1.TestResource, 0)
-		for _, item := range resourceList.Items {
+		for idx, item := range resourceList.Items {
 			if _, ok := allHosts[item.Name]; ok {
-				result = append(result, &item)
+				result = append(result, &resourceList.Items[idx])
 			}
 		}
 		return result

--- a/controllers/testworkload_controller.go
+++ b/controllers/testworkload_controller.go
@@ -32,7 +32,10 @@ import (
 )
 
 const (
-	testWorkloadFinalizer = "testworkload.naglfar.pingcap.com"
+	testWorkloadFinalizer   = "testworkload.naglfar.pingcap.com"
+	NaglfarClusterNs        = "NAGLFAR_CLUSTER_NS"
+	NaglfarTestWorkloadName = "NAGLFAR_TESTWORKLOAD_NAME"
+	NaglfarTestWorkloadItem = "NAGLFAR_TESTWORKLOAD_WORKLOAD_ITEM"
 )
 
 // TestWorkloadReconciler reconciles a TestWorkload object
@@ -203,9 +206,9 @@ func (r *TestWorkloadReconciler) getContainerConfig(
 	workloadSpec *naglfarv1.DockerContainerSpec) (image string, command []string, envs []string) {
 	image, command = workloadSpec.Image, workloadSpec.Command
 	envs = []string{}
-	envs = append(envs, fmt.Sprintf("%s=%s", "NAGLFAR_CLUSTER_NS", testWorkload.Namespace))
-	envs = append(envs, fmt.Sprintf("%s=%s", "NAGLFAR_TESTWORKLOAD_NAME", testWorkload.Name))
-	envs = append(envs, fmt.Sprintf("%s=%s", "NAGLFAR_TESTWORKLOAD_WORKLOAD_NAME", workloadSpec.Name))
+	envs = append(envs, fmt.Sprintf("%s=%s", NaglfarClusterNs, testWorkload.Namespace))
+	envs = append(envs, fmt.Sprintf("%s=%s", NaglfarTestWorkloadName, testWorkload.Name))
+	envs = append(envs, fmt.Sprintf("%s=%s", NaglfarTestWorkloadItem, workloadSpec.Name))
 	for _, item := range testWorkload.Spec.ClusterTopologiesRefs {
 		envs = append(envs, fmt.Sprintf("%s=%s", item.AliasName, item.Name))
 	}

--- a/pkg/tiup/deploy.go
+++ b/pkg/tiup/deploy.go
@@ -98,8 +98,8 @@ func BuildSpecification(ctf *naglfarv1.TestClusterTopologySpec, trs []*naglfarv1
 		return spec, nil, err
 	}
 	resourceMaps := make(map[string]*naglfarv1.TestResourceStatus)
-	for _, resource := range trs {
-		resourceMaps[resource.Name] = &resource.Status
+	for idx, resource := range trs {
+		resourceMaps[resource.Name] = &trs[idx].Status
 	}
 	control, exist := resourceMaps[ctf.TiDBCluster.Control]
 	if !exist {

--- a/pkg/tiup/deploy.go
+++ b/pkg/tiup/deploy.go
@@ -88,7 +88,7 @@ func setServerConfigs(spec *tiupSpec.Specification, serverConfigs naglfarv1.Serv
 	return nil
 }
 
-func buildSpecification(log logr.Logger, ctf *naglfarv1.TestClusterTopologySpec, rr *naglfarv1.TestResourceRequest, trs []*naglfarv1.TestResource) (spec tiupSpec.Specification, control *naglfarv1.TestResourceStatus, err error) {
+func BuildSpecification(ctf *naglfarv1.TestClusterTopologySpec, trs []*naglfarv1.TestResource) (spec tiupSpec.Specification, control *naglfarv1.TestResourceStatus, err error) {
 	spec.GlobalOptions = tiupSpec.GlobalOptions{
 		User:    "root",
 		SSHPort: 22,
@@ -191,8 +191,8 @@ type ClusterManager struct {
 	control *naglfarv1.TestResourceStatus
 }
 
-func MakeClusterManager(log logr.Logger, ctf *naglfarv1.TestClusterTopologySpec, rr *naglfarv1.TestResourceRequest, trs []*naglfarv1.TestResource) (*ClusterManager, error) {
-	specification, control, err := buildSpecification(log, ctf, rr, trs)
+func MakeClusterManager(log logr.Logger, ctf *naglfarv1.TestClusterTopologySpec, trs []*naglfarv1.TestResource) (*ClusterManager, error) {
+	specification, control, err := BuildSpecification(ctf, trs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
close #8


## testclustertoplogy API

- [x] support to retrieve the cluster topology information through the testclustertopology name
- [ ] support to manipulate the cluster(upgrade, scale-out etc)

## testworkload api

- [x] enable to upload the workload result to the testworkload CR through the testworkload name
