### PR TITLE
fix test resource cleaners do not clean exclusive disks

### DIFF
--- a/api/v1/testresource_types.go
+++ b/api/v1/testresource_types.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -234,10 +235,11 @@ func (r *TestResource) ContainerCleanerConfig(binding *ResourceBinding) (*contai
 	}
 
 	if len(mounts) > 0 {
-		config.Cmd = []string{"rm", "-rf"}
+		var subCommand []string
 		for _, mnt := range mounts {
-			config.Cmd = append(config.Cmd, path.Join(mnt.Target, "*"))
+			subCommand = append(subCommand, fmt.Sprintf("rm -rf %s", path.Join(mnt.Target, "*")))
 		}
+		config.Cmd = []string{"sh", "-c", strings.Join(subCommand, ";")}
 	}
 
 	return config, hostConfig


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

close #33

Wildcard '*' won't be expanded in a bare rm command when executing by the docker daemon, so need to wrap it with a `sh -c` command