### PR TITLE
procchaos: throw error from kill; set default value 1.25 for Machine.…

### DIFF
--- a/api/v1/machine_types.go
+++ b/api/v1/machine_types.go
@@ -94,6 +94,7 @@ type MachineSpec struct {
 	// +optional
 	DockerPort int `json:"dockerPort"`
 
+	// default is 1.25, cannot be smaller than 1.25
 	// +optional
 	DockerVersion string `json:"dockerVersion,omitempty"`
 

--- a/api/v1/machine_webhook.go
+++ b/api/v1/machine_webhook.go
@@ -64,6 +64,10 @@ func (r *Machine) Default() {
 	if r.Spec.Reserve.Memory == "" {
 		r.Spec.Reserve.Memory = util.Size(1 * units.GiB)
 	}
+
+	if r.Spec.DockerVersion == "" {
+		r.Spec.DockerVersion = "1.25"
+	}
 	// TODO(user): fill in your defaulting logic.
 }
 


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

<!-- Thank you for contributing to Naglfar!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

- The kill closure in ProcChaosReconciler doesn't throw error out.
- The default version of docker doesn't support exec env.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code


