### PR TITLE
TestClusterTopology: refactor prune code

### DIFF
--- a/api/v1/testclustertopology_types.go
+++ b/api/v1/testclustertopology_types.go
@@ -376,7 +376,7 @@ type TestClusterTopologySpec struct {
 
 type TiDBClusterInfo struct {
 	//optional
-	IsScale bool `json:"isScale,omitempty"`
+	IsScaling bool `json:"isScaling,omitempty"`
 
 	// tikvs in pendingOffline state, like [172.16.0.1:20160]
 	// +optional

--- a/api/v1/testclustertopology_types.go
+++ b/api/v1/testclustertopology_types.go
@@ -290,8 +290,6 @@ type MasterSpec struct {
 	DataDir   string `json:"dataDir" yaml:"data_dir"`
 
 	// +optional
-	NumaNode string `json:"numaNode,omitempty"`
-	// +optional
 	Config string `json:"config,omitempty"`
 	// +optional
 	LogDir string `json:"logDir,omitempty"`
@@ -307,8 +305,6 @@ type WorkerSpec struct {
 
 	// +optional
 	LogDir string `json:"logDir,omitempty"`
-	// +optional
-	NumaNode string `json:"numaNode,omitempty"`
 	// +optional
 	Config string `json:"config,omitempty"`
 }
@@ -379,6 +375,9 @@ type TestClusterTopologySpec struct {
 }
 
 type TiDBClusterInfo struct {
+	//optional
+	IsScale bool `json:"isScale,omitempty"`
+
 	// tikvs in pendingOffline state, like [172.16.0.1:20160]
 	// +optional
 	PendingOfflineList []string `json:"pendingOfflineList,omitempty"`

--- a/config/crd/bases/naglfar.pingcap.com_testclustertopologies.yaml
+++ b/config/crd/bases/naglfar.pingcap.com_testclustertopologies.yaml
@@ -654,7 +654,7 @@ spec:
               description: Info provide some information to help users understand
                 the internal state of the cluster
               properties:
-                isScale:
+                isScaling:
                   description: optional
                   type: boolean
                 offlineList:

--- a/config/crd/bases/naglfar.pingcap.com_testclustertopologies.yaml
+++ b/config/crd/bases/naglfar.pingcap.com_testclustertopologies.yaml
@@ -112,8 +112,6 @@ spec:
                         type: string
                       logDir:
                         type: string
-                      numaNode:
-                        type: string
                       peerPort:
                         type: integer
                     required:
@@ -162,8 +160,6 @@ spec:
                       host:
                         type: string
                       logDir:
-                        type: string
-                      numaNode:
                         type: string
                       port:
                         type: integer
@@ -658,6 +654,9 @@ spec:
               description: Info provide some information to help users understand
                 the internal state of the cluster
               properties:
+                isScale:
+                  description: optional
+                  type: boolean
                 offlineList:
                   description: tikvs in offline state, like [172.16.0.1:20160]
                   items:

--- a/config/crd/bases/naglfar.pingcap.com_testworkflows.yaml
+++ b/config/crd/bases/naglfar.pingcap.com_testworkflows.yaml
@@ -671,7 +671,7 @@ spec:
                             description: Info provide some information to help users
                               understand the internal state of the cluster
                             properties:
-                              isScale:
+                              isScaling:
                                 description: optional
                                 type: boolean
                               offlineList:

--- a/config/crd/bases/naglfar.pingcap.com_testworkflows.yaml
+++ b/config/crd/bases/naglfar.pingcap.com_testworkflows.yaml
@@ -126,8 +126,6 @@ spec:
                                       type: string
                                     logDir:
                                       type: string
-                                    numaNode:
-                                      type: string
                                     peerPort:
                                       type: integer
                                   required:
@@ -176,8 +174,6 @@ spec:
                                     host:
                                       type: string
                                     logDir:
-                                      type: string
-                                    numaNode:
                                       type: string
                                     port:
                                       type: integer
@@ -675,6 +671,9 @@ spec:
                             description: Info provide some information to help users
                               understand the internal state of the cluster
                             properties:
+                              isScale:
+                                description: optional
+                                type: boolean
                               offlineList:
                                 description: tikvs in offline state, like [172.16.0.1:20160]
                                 items:

--- a/pkg/tiup/dm/deploy.go
+++ b/pkg/tiup/dm/deploy.go
@@ -155,7 +155,6 @@ func BuildSpecification(ctf *naglfarv1.TestClusterTopologySpec, trs []*naglfarv1
 			Port:            item.Port,
 			DeployDir:       item.DeployDir,
 			LogDir:          item.LogDir,
-			NumaNode:        item.NumaNode,
 			ResourceControl: meta.ResourceControl{},
 		})
 		if err := setWorkerConfig(&spec, item.Config, index); err != nil {


### PR DESCRIPTION
Signed-off-by: Cadmus <CadmusJiang@gmail.com>

<!-- Thank you for contributing to Naglfar!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: By adding the IsScale attribute to skip the situation that it is not necessary to check whether the tikv scale-in is completed

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:
If the update to the cluster is scale-in, set ct.Status.TiDBClusterInfo.IsScale is updated to true.
Only when the current is in the IsScale state, we check whether we prune tikv in the tombstone state.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1.tikv(n1,n2,n3,n4)---->(n1,n2,n3)
2.tikv(n1,n2,n3)---->(n1,n2)
3.tikv(n1,n2)---->(n1,n2,n4)

Side effects

- Breaking backward compatibility
