### PR TITLE
TestClusterTopology: support upgrade tidb cluster

### DIFF
--- a/api/v1/testclustertopology_types.go
+++ b/api/v1/testclustertopology_types.go
@@ -37,7 +37,7 @@ type TiDBClusterVersion struct {
 	// +optional
 	TiKVDownloadURL string `json:"tikvDownloadURL,omitempty"`
 	// +optional
-	PDDownloadUrl string `json:"pdDownloadURL,omitempty"`
+	PDDownloadURL string `json:"pdDownloadURL,omitempty"`
 }
 
 type ServerConfigs struct {
@@ -181,7 +181,7 @@ type CDCSpec struct {
 
 type TiDBCluster struct {
 	// +optional
-	UpgradePolicy string `json:"upgradePolicy"`
+	UpgradePolicy string `json:"upgradePolicy,omitempty"`
 
 	Version TiDBClusterVersion `json:"version"`
 

--- a/api/v1/testclustertopology_types.go
+++ b/api/v1/testclustertopology_types.go
@@ -180,6 +180,9 @@ type CDCSpec struct {
 }
 
 type TiDBCluster struct {
+	// +optional
+	UpgradePolicy string `json:"upgradePolicy"`
+
 	Version TiDBClusterVersion `json:"version"`
 
 	// +optional

--- a/api/v1/testclustertopology_webhook.go
+++ b/api/v1/testclustertopology_webhook.go
@@ -118,10 +118,10 @@ func (r *TestClusterTopology) validateTiDBUpdate(tct *TestClusterTopology) error
 		return fmt.Errorf("update unsupport components")
 	}
 
-	if !checkOnlyOneUpdation(tct.Status.PreTiDBCluster, r.Spec.TiDBCluster){
+	if !checkOnlyOneUpdation(tct.Status.PreTiDBCluster, r.Spec.TiDBCluster) {
 		return fmt.Errorf("only one of [upgrade, modify serverConfigs, scale-in/out] can be executed at a time")
 	}
-	if !checkUpgradePolicy(r.Spec.TiDBCluster){
+	if !checkUpgradePolicy(r.Spec.TiDBCluster) {
 		return fmt.Errorf("upgradePolicy must be `force` or empty")
 	}
 
@@ -314,7 +314,7 @@ func checkUpgrade(pre *TiDBCluster, cur *TiDBCluster) bool {
 	return pre.Version.Version != cur.Version.Version
 }
 
-func checkVersionDownloadURL(pre *TiDBCluster, cur *TiDBCluster) bool{
+func checkVersionDownloadURL(pre *TiDBCluster, cur *TiDBCluster) bool {
 	return pre.Version.PDDownloadURL != cur.Version.PDDownloadURL || pre.Version.TiDBDownloadURL != cur.Version.TiDBDownloadURL || pre.Version.TiKVDownloadURL != cur.Version.TiKVDownloadURL
 }
 
@@ -329,9 +329,9 @@ func checkOnlyOneUpdation(pre *TiDBCluster, cur *TiDBCluster) bool {
 	if checkUpgrade(pre, cur) {
 		updatedModules++
 	}
-	return updatedModules==1
+	return updatedModules == 1
 }
 
-func checkUpgradePolicy(cur *TiDBCluster) bool{
-	return cur.UpgradePolicy=="force"||cur.UpgradePolicy==""
+func checkUpgradePolicy(cur *TiDBCluster) bool {
+	return cur.UpgradePolicy == "force" || cur.UpgradePolicy == ""
 }

--- a/config/crd/bases/naglfar.pingcap.com_testclustertopologies.yaml
+++ b/config/crd/bases/naglfar.pingcap.com_testclustertopologies.yaml
@@ -417,6 +417,8 @@ spec:
                     - host
                     type: object
                   type: array
+                upgradePolicy:
+                  type: string
                 version:
                   description: 'TODO: add a deploy version spec: clusterName, base
                     version, component versions(for PR and self build version) etc.'
@@ -656,6 +658,8 @@ spec:
                     - host
                     type: object
                   type: array
+                upgradePolicy:
+                  type: string
                 version:
                   description: 'TODO: add a deploy version spec: clusterName, base
                     version, component versions(for PR and self build version) etc.'

--- a/config/crd/bases/naglfar.pingcap.com_testworkflows.yaml
+++ b/config/crd/bases/naglfar.pingcap.com_testworkflows.yaml
@@ -431,6 +431,8 @@ spec:
                                   - host
                                   type: object
                                 type: array
+                              upgradePolicy:
+                                type: string
                               version:
                                 description: 'TODO: add a deploy version spec: clusterName,
                                   base version, component versions(for PR and self
@@ -672,6 +674,8 @@ spec:
                                   - host
                                   type: object
                                 type: array
+                              upgradePolicy:
+                                type: string
                               version:
                                 description: 'TODO: add a deploy version spec: clusterName,
                                   base version, component versions(for PR and self

--- a/controllers/testclustertopology_controller.go
+++ b/controllers/testclustertopology_controller.go
@@ -270,6 +270,7 @@ func (r *TestClusterTopologyReconciler) upgradeTiDBCluster(ctx context.Context, 
 	var resources []*naglfarv1.TestResource
 	if err := r.List(ctx, &resourceList, client.InNamespace(rr.Namespace), client.MatchingFields{resourceOwnerKey: rr.Name}); err != nil {
 		log.Error(err, "unable to list child resources")
+		return true, nil
 	}
 	resources = filterClusterResources(ct, resourceList)
 

--- a/controllers/testclustertopology_controller.go
+++ b/controllers/testclustertopology_controller.go
@@ -270,7 +270,7 @@ func (r *TestClusterTopologyReconciler) upgradeTiDBCluster(ctx context.Context, 
 	var resources []*naglfarv1.TestResource
 	if err := r.List(ctx, &resourceList, client.InNamespace(rr.Namespace), client.MatchingFields{resourceOwnerKey: rr.Name}); err != nil {
 		log.Error(err, "unable to list child resources")
-		return true, nil
+		return false, error
 	}
 	resources = filterClusterResources(ct, resourceList)
 

--- a/controllers/testclustertopology_controller.go
+++ b/controllers/testclustertopology_controller.go
@@ -260,6 +260,27 @@ func (r *TestClusterTopologyReconciler) installTiDBCluster(ctx context.Context, 
 	return false, tiupCtl.InstallCluster(log, ct.Name, ct.Spec.TiDBCluster.Version)
 }
 
+func (r *TestClusterTopologyReconciler) upgradeTiDBCluster(ctx context.Context, ct *naglfarv1.TestClusterTopology, rr *naglfarv1.TestResourceRequest) (requeue bool, err error) {
+	log := r.Log.WithValues("upgradeTiDBCluster", types.NamespacedName{
+		Namespace: ct.Namespace,
+		Name:      ct.Name,
+	})
+
+	var resourceList naglfarv1.TestResourceList
+	var resources []*naglfarv1.TestResource
+	if err := r.List(ctx, &resourceList, client.InNamespace(rr.Namespace), client.MatchingFields{resourceOwnerKey: rr.Name}); err != nil {
+		log.Error(err, "unable to list child resources")
+	}
+	resources = filterClusterResources(ct, resourceList)
+
+	tiupCtl, err := cluster.MakeClusterManager(log, ct.Spec.DeepCopy(), resources)
+
+	if err != nil {
+		return false, err
+	}
+	return false, tiupCtl.UpgradeCluster(log, ct.Name, ct, hostname2ClusterIP(resourceList))
+}
+
 func (r *TestClusterTopologyReconciler) updateServerConfigs(ctx context.Context, ct *naglfarv1.TestClusterTopology, rr *naglfarv1.TestResourceRequest) (requeue bool, err error) {
 	log := r.Log.WithValues("updateServerConfigs", types.NamespacedName{
 		Namespace: ct.Namespace,
@@ -567,6 +588,16 @@ func (r *TestClusterTopologyReconciler) pruneTiDBCluster(ctx context.Context, ct
 
 func (r *TestClusterTopologyReconciler) updateTiDBCluster(ctx context.Context, ct *naglfarv1.TestClusterTopology, rr *naglfarv1.TestResourceRequest) (isOk bool, result ctrl.Result, err error) {
 
+	if cluster.IsUpgraded(ct.Status.PreTiDBCluster, ct.Spec.TiDBCluster) {
+		requeue, err := r.upgradeTiDBCluster(ctx, ct, rr)
+		if err != nil {
+			r.Recorder.Event(ct, "Warning", "Upgrade", err.Error())
+			return false, ctrl.Result{}, err
+		}
+		if requeue {
+			return false, ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+	}
 	if cluster.IsServerConfigModified(ct.Status.PreTiDBCluster.ServerConfigs, ct.Spec.TiDBCluster.ServerConfigs) {
 		// update serverConfig
 		requeue, err := r.updateServerConfigs(ctx, ct, rr)

--- a/controllers/testclustertopology_controller.go
+++ b/controllers/testclustertopology_controller.go
@@ -270,7 +270,7 @@ func (r *TestClusterTopologyReconciler) upgradeTiDBCluster(ctx context.Context, 
 	var resources []*naglfarv1.TestResource
 	if err := r.List(ctx, &resourceList, client.InNamespace(rr.Namespace), client.MatchingFields{resourceOwnerKey: rr.Name}); err != nil {
 		log.Error(err, "unable to list child resources")
-		return false, error
+		return false, err
 	}
 	resources = filterClusterResources(ct, resourceList)
 

--- a/pipeline-examples/topology.yaml
+++ b/pipeline-examples/topology.yaml
@@ -21,6 +21,7 @@ spec:
         schedule.leader-schedule-limit: 4
         schedule.region-schedule-limit: 2048
         schedule.replica-schedule-limit: 64
+    upgradePolicy: force
     version:
       version: nightly
     control: n1

--- a/pkg/tiup/cluster/deploy.go
+++ b/pkg/tiup/cluster/deploy.go
@@ -441,13 +441,9 @@ func (c *ClusterManager) UpgradeCluster(log logr.Logger, clusterName string, ct 
 		return err
 	}
 	defer client.Close()
-	var forceFlag string
-	if ct.Spec.TiDBCluster.UpgradePolicy == "force" {
-		forceFlag = "--force"
-	}
 
 	log.Info("cluster is upgrading", "oldVersion", ct.Status.PreTiDBCluster.Version.Version, "newVersion", ct.Spec.TiDBCluster.Version.Version)
-	cmd := fmt.Sprintf("/root/.tiup/bin/tiup cluster upgrade %s %s %s -y", clusterName, ct.Spec.TiDBCluster.Version.Version, forceFlag)
+	cmd := fmt.Sprintf("/root/.tiup/bin/tiup cluster upgrade %s %s %s -y", clusterName, ct.Spec.TiDBCluster.Version.Version, ct.Spec.TiDBCluster.UpgradePolicy)
 	stdStr, errStr, err := client.RunCommand(cmd)
 	if err != nil {
 		log.Error(err, "run command on remote failed",
@@ -738,7 +734,7 @@ func (c *ClusterManager) reloadCluster(clusterName string, nodes []string, roles
 }
 
 func (c *ClusterManager) shouldPatch(version naglfarv1.TiDBClusterVersion) bool {
-	return version.TiDBDownloadURL != "" || version.PDDownloadUrl != "" || version.TiKVDownloadURL != ""
+	return version.TiDBDownloadURL != "" || version.PDDownloadURL != "" || version.TiKVDownloadURL != ""
 }
 
 func (c *ClusterManager) patch(clusterName string, version naglfarv1.TiDBClusterVersion) error {
@@ -768,10 +764,10 @@ func (c *ClusterManager) patch(clusterName string, version naglfarv1.TiDBCluster
 		})
 		patchComponentNames = append(patchComponentNames, "tikv-server")
 	}
-	if version.PDDownloadUrl != "" {
+	if version.PDDownloadURL != "" {
 		patchComponents = append(patchComponents, component{
 			componentName: "pd-server",
-			downloadURL:   version.PDDownloadUrl,
+			downloadURL:   version.PDDownloadURL,
 		})
 		patchComponentNames = append(patchComponentNames, "pd-server")
 	}

--- a/pkg/tiup/cluster/deploy.go
+++ b/pkg/tiup/cluster/deploy.go
@@ -442,8 +442,13 @@ func (c *ClusterManager) UpgradeCluster(log logr.Logger, clusterName string, ct 
 	}
 	defer client.Close()
 
+	var forceFlag string
+	if ct.Spec.TiDBCluster.UpgradePolicy == "force" {
+		forceFlag = "--force"
+	}
+
 	log.Info("cluster is upgrading", "oldVersion", ct.Status.PreTiDBCluster.Version.Version, "newVersion", ct.Spec.TiDBCluster.Version.Version)
-	cmd := fmt.Sprintf("/root/.tiup/bin/tiup cluster upgrade %s %s %s -y", clusterName, ct.Spec.TiDBCluster.Version.Version, ct.Spec.TiDBCluster.UpgradePolicy)
+	cmd := fmt.Sprintf("/root/.tiup/bin/tiup cluster upgrade %s %s %s -y", clusterName, ct.Spec.TiDBCluster.Version.Version, forceFlag)
 	stdStr, errStr, err := client.RunCommand(cmd)
 	if err != nil {
 		log.Error(err, "run command on remote failed",


### PR DESCRIPTION
Signed-off-by: Cadmus <CadmusJiang@gmail.com>

<!-- Thank you for contributing to Naglfar!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: support upgrade tidb cluster

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
How it Works:
If tct.Spec.TiDBCluster.Version.Version!= tct.Status.PreTiDBCluster.Version.Version, call cmd(tiup cluster upgrade).
If tct.Spec.TiDBCluster.UpgradePolicy=="force",add flag(--force)

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1.v4.0.0-->v4.0.9(no force)
2.v4.0.9-->v5.0.0-rc(no force)
3.v5.0.0-rc-->nightly(--force)

Side effects

- Breaking backward compatibility
