### PR TITLE
Bugfix: workload should disable to create on an already running test resource

### DIFF
--- a/api/v1/testresource_types.go
+++ b/api/v1/testresource_types.go
@@ -172,7 +172,8 @@ type TestResourceStatus struct {
 	Phase ResourcePhase `json:"phase,omitempty"`
 
 	// means the container's exit code
-	ExitCode int `json:"exitCode"`
+	// +optional
+	ExitCode int `json:"exitCode,omitempty"`
 
 	ResourceContainerSpec `json:",inline"`
 

--- a/config/crd/bases/naglfar.pingcap.com_testresources.yaml
+++ b/config/crd/bases/naglfar.pingcap.com_testresources.yaml
@@ -201,8 +201,6 @@ spec:
               - finish
               - destroy
               type: string
-          required:
-          - exitCode
           type: object
       type: object
   version: v1

--- a/controllers/testworkload_controller.go
+++ b/controllers/testworkload_controller.go
@@ -169,6 +169,8 @@ func (r *TestWorkloadReconciler) reconcilePending(ctx context.Context, workload 
 			}
 		case naglfarv1.ResourceReady, naglfarv1.ResourceFinish:
 			self := ref.CreateRef(&workload.ObjectMeta)
+			// check if the workload node resource is used by a tct(ClaimRef == nil)
+			// or has occupied by another workload (Claim != self)
 			if workloadNode.Status.ClaimRef == nil || *workloadNode.Status.ClaimRef != self {
 				err := fmt.Errorf("resource %s is used by others now, wait", workloadNode.Name)
 				r.Recorder.Eventf(workload, "Warning", "Precondition", err.Error())

--- a/controllers/testworkload_controller.go
+++ b/controllers/testworkload_controller.go
@@ -168,6 +168,12 @@ func (r *TestWorkloadReconciler) reconcilePending(ctx context.Context, workload 
 				return ctrl.Result{}, err
 			}
 		case naglfarv1.ResourceReady, naglfarv1.ResourceFinish:
+			self := ref.CreateRef(&workload.ObjectMeta)
+			if workloadNode.Status.ClaimRef == nil || *workloadNode.Status.ClaimRef != self {
+				err := fmt.Errorf("resource %s is used by others now, wait", workloadNode.Name)
+				r.Recorder.Eventf(workload, "Warning", "Precondition", err.Error())
+				return ctrl.Result{}, err
+			}
 			installedCount += 1
 		default:
 			panic(fmt.Sprintf("there's a bug, forget to process the `%s` state", workloadNode.Status.State))


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

<!-- Thank you for contributing to Naglfar!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #106 <!-- REMOVE this line if no issue to close -->

Problem Summary: workload should disable to create on an already running test resource

### What is changed and how it works?

Check the resource.Status.ClaimRef to confirm the owner.

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Breaking backward compatibility
