### PR TITLE
daemon: fix the daemon starting logic bug

### DIFF
--- a/api/v1/testclustertopology_types.go
+++ b/api/v1/testclustertopology_types.go
@@ -230,10 +230,11 @@ type TiDBCluster struct {
 func (c *TiDBCluster) AllHosts() map[string]struct{} {
 	components := []string{TiDBField, TiKVField, PDField, MonitorField, GrafanaField, CDCField, TiFlashField}
 	result := map[string]struct{}{
-		c.Control:      {},
-		c.HAProxy.Host: {},
+		c.Control: {},
 	}
-
+	if c.HAProxy != nil {
+		result[c.HAProxy.Host] = struct{}{}
+	}
 	val := reflect.ValueOf(*c)
 	for i := 0; i < val.Type().NumField(); i++ {
 		if checkIn(components, val.Type().Field(i).Name) {

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -131,7 +131,6 @@ func (r *MachineReconciler) reconcileStarting(log logr.Logger, machine *naglfarv
 	}
 
 	machine.Status.State = naglfarv1.MachineReady
-	machine.Status.UploadPort = container.UploadDaemonExternalPort
 
 	if err = r.Status().Update(r.Ctx, machine); err != nil {
 		log.Error(err, "unable to update Machine")

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -338,7 +338,7 @@ func (r *MachineReconciler) createUploadDaemon(machine *naglfarv1.Machine, docke
 		return 0, err
 	}
 	if uploadPort == 0 {
-		panic(fmt.Sprintf("there's a bug, uploadPort should be zero"))
+		panic("there's a bug, uploadPort should be zero")
 	}
 	return
 }

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -140,7 +140,7 @@ func (r *MachineReconciler) reconcileStarting(log logr.Logger, machine *naglfarv
 }
 
 func (r *MachineReconciler) reconcileRunning(log logr.Logger, machine *naglfarv1.Machine) (ctrl.Result, error) {
-	if machine.Status.UploadPort != 0 {
+	if machine.Status.UploadPort == 0 {
 		dockerClient, err := dockerutil.MakeClient(r.Ctx, machine)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -151,6 +151,11 @@ func (r *MachineReconciler) reconcileRunning(log logr.Logger, machine *naglfarv1
 			r.Eventer.Event(machine, "Warning", "upload-daemon", err.Error())
 			return ctrl.Result{}, err
 		}
+		err = r.Status().Update(r.Ctx, machine)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 	relation, err := r.getRelationship()
 	if err != nil {
@@ -323,14 +328,19 @@ func (r *MachineReconciler) createUploadDaemon(machine *naglfarv1.Machine, docke
 		err = fmt.Errorf("invalid occupy container: %s", stat.Name)
 	}
 
-	port := strconv.Itoa(container.UploadDaemonExternalPort) + "/tcp"
+	port := strconv.Itoa(container.UploadDaemonInternalPort) + "/tcp"
 	if ports, ok := stat.NetworkSettings.Ports[nat.Port(port)]; ok && len(ports) > 0 {
 		uploadPort, err = strconv.Atoi(ports[0].HostPort)
 		if err != nil {
 			return
 		}
 	}
-
+	if err != nil {
+		return 0, err
+	}
+	if uploadPort == 0 {
+		panic(fmt.Sprintf("there's a bug, uploadPort should be zero"))
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

<!-- Thank you for contributing to Naglfar!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: I fail to upgrade Naglfar to 413632b33a506c024d1839e0ad4d34969e3b2523, because of the upload-daemon aren't launched.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Fix the error daemon launching logic error.

How it Works:

Because all existing machines are in the running phase, machines skip launching upload daemon because uploadPort is set on starting phase.

For compatibility with existing machines, this PR launch the upload daemon logic on the reconcileRunning phase.


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Breaking backward compatibility
