### PR TITLE
fix #118: wrap the stdout output on events when cluster fails to deploy

### DIFF
--- a/pkg/tiup/cluster/deploy.go
+++ b/pkg/tiup/cluster/deploy.go
@@ -678,15 +678,15 @@ func (c *ClusterManager) deployCluster(log logr.Logger, clusterName string, vers
 	cmd := fmt.Sprintf("/root/.tiup/bin/tiup cluster deploy -y %s %s /root/topology.yaml -i %s", clusterName, version, tiup.InsecureKeyPath)
 	stdStr, errStr, err := client.RunCommand(cmd)
 	if err != nil {
+		if strings.Contains(errStr, "specify another cluster name") {
+			return tiup.ErrClusterDuplicated{ClusterName: clusterName}
+		}
 		log.Error(err, "run command on remote failed",
 			"host", fmt.Sprintf("%s@%s:%d", "root", c.control.HostIP, c.control.SSHPort),
 			"command", cmd,
 			"stdout", stdStr,
 			"stderr", errStr)
-		if strings.Contains(errStr, "specify another cluster name") {
-			return tiup.ErrClusterDuplicated{ClusterName: clusterName}
-		}
-		return fmt.Errorf("deploy cluster failed(%s): %s", err, errStr)
+		return fmt.Errorf("deploy cluster failed(%s): %s\n\n%s", err, stdStr, errStr)
 	}
 	return nil
 }

--- a/pkg/tiup/cluster/deploy.go
+++ b/pkg/tiup/cluster/deploy.go
@@ -361,7 +361,9 @@ func BuildSpecification(ctf *naglfarv1.TestClusterTopologySpec, trs []*naglfarv1
 	}
 
 	// set default values from tag
-	defaults.Set(&spec)
+	if err := defaults.Set(&spec); err != nil {
+		panic(err)
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

Issue Number: close #118  <!-- REMOVE this line if no issue to close -->

Problem Summary:

Wrap the stdout output on events when cluster fails to deploy 

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Breaking backward compatibility
