### PR TITLE
tct: adds the NET_ADMIN capability for the support of network chaos

### DIFF
--- a/controllers/testclustertopology_controller.go
+++ b/controllers/testclustertopology_controller.go
@@ -753,7 +753,7 @@ func (r *TestClusterTopologyReconciler) initTiDBResources(ctx context.Context, c
 			requeue = true
 			if resource.Status.Image == "" {
 				resource.Status.Image = tiup.ContainerImage
-				resource.Status.CapAdd = []string{"SYS_ADMIN", "SYS_PTRACE"}
+				resource.Status.CapAdd = []string{"SYS_ADMIN", "SYS_PTRACE", "NET_ADMIN"}
 				resource.Status.Binds = append(resource.Status.Binds, "/sys/fs/cgroup:/sys/fs/cgroup:ro")
 				resource.Status.ExposedPorts = exposedPortIndexer[resource.Name]
 				err := r.Status().Update(ctx, resource)

--- a/docker/base-image
+++ b/docker/base-image
@@ -14,6 +14,7 @@ RUN yum update -y && \
     yum install -y sudo mysql vim iproute tzdata \
         gdb perf \
         openssh openssh-server openssh-clients && \
+    yum install -y iptables ipset iproute2 && \
     debuginfo-install -y glibc libgcc && \
     sed -e 's/#PermitRootLogin yes/PermitRootLogin yes/g' \
       -i /etc/ssh/sshd_config && \


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve?

This PR adds the NET_ADMIN capability for the support of network chaos

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Breaking backward compatibility
