### PR TITLE
fix: pkg tiup patch needs '-y' to affirm; or it will abort.

### DIFF
--- a/pkg/tiup/cluster/deploy.go
+++ b/pkg/tiup/cluster/deploy.go
@@ -847,7 +847,7 @@ func (c *ClusterManager) patch(clusterName string, version naglfarv1.TiDBCluster
 	}
 	commands = append(commands, "cd components && tar zcf patch.tar.gz "+strings.Join(patchComponentNames, " "))
 	for _, component := range patchComponentNames {
-		commands = append(commands, fmt.Sprintf("/root/.tiup/bin/tiup cluster patch %s patch.tar.gz -R %s",
+		commands = append(commands, fmt.Sprintf("/root/.tiup/bin/tiup cluster patch %s patch.tar.gz -R %s -y",
 			clusterName, strings.Split(component, "-server")[0]))
 	}
 	cmd := fmt.Sprintf(`flock -n /tmp/naglfar.tiup.lock -c "%s"`, strings.Join(commands, "\n"))


### PR DESCRIPTION
### What problem does this PR solve?
when I need to use patch with naglfar, there comes an error and the log as follows:
`+ /root/.tiup/bin/tiup cluster patch tidb-cluster patch.tar.gz -R tidb

Error: Operation aborted by user (with answer '') (cliutil.operation_aborted)`

### The source of the problem
tiup patch need '-y' to confirm the procession now, and default flag is '-N'

### No test been done

Signed-off-by: Edric Morris <codingpoeta@gmail.com>
